### PR TITLE
Fix min-max point bug in const-sum questions

### DIFF
--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.html
@@ -34,8 +34,8 @@
             <div class="col-sm-6">
               <input id="total-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="false"
                      (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Checkbox">
-              <input id="total-points" type="number" class="form-control" min="1" step="1"
-                     [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption" aria-label="Total Points Input">
+              <input id="total-points" type="number" class="form-control"
+                     [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', ceil($event))" [disabled]="!isEditable || model.pointsPerOption" [step]="1" aria-label="Total Points Input">
             </div>
             <div class="col-sm-6 text-start">
               <b class="ngb-tooltip-class" ngbTooltip="Respondents will have to distribute the total points specified here among the options, e.g. if you specify 100 points here and there are 3 options, respondents will have to distribute 100 points among 3 options.">in total</b>
@@ -47,8 +47,8 @@
             <div class="col-sm-6">
               <input id="per-option-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="true"
                      (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Times Number of Options Checkbox">
-              <input id="per-option-points" type="number" class="form-control" min="1" step="1"
-                     [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption" aria-label="Points Input">
+              <input id="per-option-points" type="number" class="form-control" 
+                     [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', ceil($event))" [disabled]="!isEditable || !model.pointsPerOption" [step]="1" aria-label="Points Input">
             </div>
             <div class="col-sm-6 text-start">
               <b class="ngb-tooltip-class" ngbTooltip="The number of points to distribute will vary based on the number of options, e.g. if you specify 100 points here and there are 3 options, the total number of points to distribute among 3 options will be 300 (i.e. 100 x 3).">times (number of options)</b>
@@ -64,8 +64,8 @@
                 <input id="min-point-checkbox" class="form-check-input" type="checkbox"
                        [ngModel]="hasMinPoint"
                        (ngModelChange)="resetMinPoint($event)" [disabled]="!isEditable" aria-label="Minimum Value Checkbox">
-                <input id="min-point" type="number" class="form-control" min="1" step="1"
-                       [ngModel]="hasMinPoint ? model.minPoint : ''" (ngModelChange)="triggerModelChange('minPoint', $event)" [disabled]="!isEditable || !hasMinPoint" aria-label="Minimum Value Input">
+                <input id="min-point" type="number" class="form-control" 
+                       [ngModel]="hasMinPoint ? model.minPoint : ''" (ngModelChange)="triggerModelChange('minPoint', ceil($event))" [disabled]="!isEditable || !hasMinPoint" [step]="1" aria-label="Minimum Value Input">
                 <b class="ngb-tooltip-class" ngbTooltip="The minimum allocation of the points to an option, e.g if you specify 5 points here, the user must input a value larger than or equal to 5 for each option.">minimum per option</b>
               </label>
             </div>
@@ -76,8 +76,8 @@
                 <input id="max-point-checkbox" class="form-check-input" type="checkbox"
                        [ngModel]="hasMaxPoint"
                        (ngModelChange)="resetMaxPoint($event)"  [disabled]="!isEditable" aria-label="Maximum Value Checkbox">
-                <input id="max-point" type="number" class="form-control" min="1" step="1"
-                       [ngModel]="hasMaxPoint ? model.maxPoint : ''" (ngModelChange)="triggerModelChange('maxPoint', $event)" [disabled]="!isEditable || !hasMaxPoint" aria-label="Maximum Value Input">
+                <input id="max-point" type="number" class="form-control" 
+                       [ngModel]="hasMaxPoint ? model.maxPoint : ''" (ngModelChange)="triggerModelChange('maxPoint', ceil($event))" [disabled]="!isEditable || !hasMaxPoint" [step]="1" aria-label="Maximum Value Input">
                 <b class="ngb-tooltip-class" ngbTooltip="The maximum allocation of the points to an option, e.g if you specify 30 points here, the user must input a value smaller than or equal to 30 for each option.">maximum per option</b>
               </label>
             </div>

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-options-question-edit-details-form.component.ts
@@ -27,6 +27,10 @@ export class ConstsumOptionsQuestionEditDetailsFormComponent
     super(DEFAULT_CONSTSUM_OPTIONS_QUESTION_DETAILS());
   }
 
+  ceil(value: number): number {
+    return value === null  ? value : Math.ceil(value);
+  }
+
   get hasMaxPoint(): boolean {
     return this.model.maxPoint !== undefined;
   }

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.html
@@ -9,8 +9,8 @@
         <div class="col-sm-3">
           <input id="total-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="false"
                  (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Checkbox">
-          <input id="total-points" type="number" class="form-control" min="1" step="1"
-                 [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || model.pointsPerOption" aria-label="Total Points Input">
+          <input id="total-points" type="number" class="form-control" 
+                 [ngModel]="!model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', ceil($event))" [disabled]="!isEditable || model.pointsPerOption" [step]="1" aria-label="Total Points Input">
         </div>
         <div class="col-sm-9 text-start">
           <b class="ngb-tooltip-class" ngbTooltip="Respondents will have to distribute the total points specified here among the recipients, e.g. if you specify 100 points here and there are 3 recipients, respondents will have to distribute 100 points among 3 recipients.">in total</b>
@@ -22,8 +22,8 @@
         <div class="col-sm-3">
           <input id="per-option-points-radio" class="form-check-input" type="radio" [ngModel]="model.pointsPerOption" [value]="true"
                  (ngModelChange)="triggerModelChange('pointsPerOption', $event)" [disabled]="!isEditable" aria-label="Use Total Points Times Number of Recipients Checkbox">
-          <input id="per-option-points" type="number" class="form-control" min="1" step="1"
-                 [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', $event)" [disabled]="!isEditable || !model.pointsPerOption" aria-label="Points Input">
+          <input id="per-option-points" type="number" class="form-control" 
+                 [ngModel]="model.pointsPerOption ? model.points : ''" (ngModelChange)="triggerModelChange('points', ceil($event))" [disabled]="!isEditable || !model.pointsPerOption" [step]="1"  aria-label="Points Input">
         </div>
         <div class="col-sm-9 text-start">
           <b class="ngb-tooltip-class" ngbTooltip="The number of points to distribute will vary based on the number of recipients, e.g. if you specify 100 points here and there are 3 recipients, the total number of points to distribute among 3 recipients will be 300 (i.e. 100 x 3).">times (number of recipients)</b>

--- a/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.ts
+++ b/src/web/app/components/question-types/question-edit-details-form/constsum-recipients-question-edit-details-form.component.ts
@@ -27,6 +27,10 @@ export class ConstsumRecipientsQuestionEditDetailsFormComponent
     super(DEFAULT_CONSTSUM_RECIPIENTS_QUESTION_DETAILS());
   }
 
+  ceil(value: number): number {
+    return value === null  ? value : Math.ceil(value);
+  }
+
   /**
    * Changes force uneven distribution option.
    */


### PR DESCRIPTION
**Issue Identified**

<img width="905" alt="image" src="https://github.com/dlimyy/teammates/assets/97420966/e53dd821-bc54-4b28-9248-a835f1012b2b">
<img width="932" alt="image" src="https://github.com/dlimyy/teammates/assets/97420966/32581e0b-8c00-411c-bed9-984bc9a911f0">

Currently, there is a NumberFormatException which arises when decimal numbers are entered into the point fields of the distribute points questions. This is caused by the lack of validation check to ensure that the number passed into these fields are always integer

**Outline of Solution**
To fix this issue, I made it such that the number inputted will always be an integer so if the user tries keying in a number such as 99.5, it will be rounded up to 100. This helps to prevent this error from occurring and also reduces amount of code which has to be changed to accommodate decimals

Screen recording of solution
https://github.com/dlimyy/teammates/assets/97420966/46bc63b0-4ad5-4e57-b77a-4b0a337723a6